### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: GitHub Actions Build Test
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/FlutterGenerator/iperf/security/code-scanning/4](https://github.com/FlutterGenerator/iperf/security/code-scanning/4)

To fix the problem, add a `permissions` block at either the workflow root (applies to all jobs unless overridden) or in each job. The least privilege needed here appears to be `contents: read`, as the jobs only check out the repository and run tests/builds, not creating or modifying issues, PRs, or repository contents. This fix involves adding the following snippet just below the `name:` and before `on:` in `.github/workflows/build.yml`:

```yaml
permissions:
  contents: read
```

No other changes, imports, or method definitions are required. The fix is confined to a small YAML snippet at the root level of the workflow for broad coverage and simplicity.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
